### PR TITLE
minor improvements and added test case

### DIFF
--- a/src/amr.py
+++ b/src/amr.py
@@ -21,12 +21,14 @@ from pprint import pprint
 from collections import defaultdict, namedtuple, Counter, Container
 
 from parsimonious.grammar import Grammar
+from parsimonious.exceptions import ParseError
 from nltk.parse import DependencyGraph
 
 def clean_grammar_file(s):
     return re.sub('\n[ \t]+', ' ', re.sub(r'#.*','',s.replace('\t',' ').replace('`','_backtick')))
 
-with open('amr.peg') as inF:
+scriptdir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(scriptdir, 'amr.peg')) as inF:
     grammar = Grammar(clean_grammar_file(inF.read()))
 
 
@@ -255,7 +257,10 @@ class AMR(DependencyGraph):
         self.nodes[TOP]['type'] = 'TOP'
         if anno:
             self._anno = anno
-            p = grammar.parse(anno)
+            try:
+                p = grammar.parse(anno)
+            except ParseError as e:
+                raise AMRSyntaxError('Bad parse: '+str(e))
             if p is None:
                 raise AMRSyntaxError('Well-formedness error in annotation:\n'+anno.strip())
             self._analyze(p)

--- a/src/amr.py
+++ b/src/amr.py
@@ -558,7 +558,9 @@ expressive
                  :calendar (c2 / country :wiki "Japan"
                        :name (n2 / name :op1 "Japan"))))''',
 ''' (d / date-entity :polite +
-           :time (a / amr-unknown))'''
+           :time (a / amr-unknown))''',
+'''( o / have-01 :ARG0 o :value 2)''',
+#'''( o / have-01 :ARG0 o :value -2)'''  # causes errors if uncommented
 ]
 
 sembad_tests = [    # not a syntax error, but malformed in terms of variables


### PR DESCRIPTION
first i added relative pathname handling so amr.py could be called from a directory other than src and so that the test would complete with proper error handling of the bad amr.

then i added two test amrs that should both be good. the second one causes a crash. see the issue raised.
