### PR TITLE
Always keep alignments by triple

### DIFF
--- a/src/amr.py
+++ b/src/amr.py
@@ -219,6 +219,18 @@ class AMR(DependencyGraph):
         :result (s / silly-01~e.4[silly]
             :ARG1 y))
 
+    >>> a = AMR("(h / hug-01~e.3 :ARG0 (a / and~e.1 :op1 (y / you~e.0) :op2 (i / i~e.2)) \
+                 :ARG1 (a2 / and~e.5 :op1 (s / she~e.4) :op2 (h2 / he~e.6)))", \
+                "You and I hug her and him".split())
+    >>> a
+    (h / hug-01~e.3[hug]
+        :ARG0 (a / and~e.1[and]
+            :op1 (y / you~e.0[You])
+            :op2 (i / i~e.2[I]))
+        :ARG1 (a2 / and~e.5[and]
+            :op1 (s / she~e.4[her])
+            :op2 (h2 / he~e.6[him])))
+
     >>> a = AMR('(r / reduce-01~e.8 :ARG0 (t / treat-04~e.0 :ARG1~e.1 (c / cell-line~e.3,4 \
                 :mod (d2 / disease :name (n3 / name :op1 "CRC"~e.2))) :ARG2~e.5 (s / small-molecule \
                 :name (n / name :op1 "U0126"~e.6))) :ARG1 (l / level~e.11 :quant-of (n6 / nucleic-acid \

--- a/src/amr.py
+++ b/src/amr.py
@@ -231,6 +231,23 @@ class AMR(DependencyGraph):
             :op1 (s / she~e.4[her])
             :op2 (h2 / he~e.6[him])))
 
+    >>> a = AMR("(a / and~e.5 :op1 (e / eat-01~e.2 :ARG0 (c / cat~e.1,8 :poss~e.0,8 (i / i~e.0,8)) \
+                 :time~e.3 (d / dawn~e.4)) \
+                 :op2 (e2 / eat-01~e.2 :ARG0 (c2 / cat~e.1,6 :poss~e.6 (y / you~e.6)) \
+                 :time~e.7 (a2 / after~e.7 :op1 e~e.9)))", \
+                "my cat eats at dawn and yours after mine does".split())
+    >>> a
+    (a / and~e.5[and]
+        :op1 (e / eat-01~e.2[eats]
+            :ARG0 (c / cat~e.1,8[cat,mine]
+                :poss~e.0,8[my,mine] (i / i~e.0,8[my,mine]))
+            :time~e.3[at] (d / dawn~e.4[dawn]))
+        :op2 (e2 / eat-01~e.2[eats]
+            :ARG0 (c2 / cat~e.1,6[cat,yours]
+                :poss~e.6[yours] (y / you~e.6[yours]))
+            :time~e.7[after] (a2 / after~e.7[after]
+                :op1 e~e.9[does])))
+
     >>> a = AMR('(r / reduce-01~e.8 :ARG0 (t / treat-04~e.0 :ARG1~e.1 (c / cell-line~e.3,4 \
                 :mod (d2 / disease :name (n3 / name :op1 "CRC"~e.2))) :ARG2~e.5 (s / small-molecule \
                 :name (n / name :op1 "U0126"~e.6))) :ARG1 (l / level~e.11 :quant-of (n6 / nucleic-acid \

--- a/src/amr.py
+++ b/src/amr.py
@@ -187,12 +187,20 @@ class AMR(DependencyGraph):
                     :op1 "arizona"~e.8))
             :manner~e.0 (g / glance-01~e.2
                 :arg0 i)))
-    >>> a.alignments()  #doctest:+NORMALIZE_WHITESPACE
-    {(Var(d), ':manner', Var(g)): 'e.0', Concept(glance-01): 'e.2',
-    "china": 'e.6', (Var(s), ':wiki', "arizona"): 'e.7', Concept(i): 'e.3',
-    "arizona": 'e.8', (Var(p), ':domain', Var(d)): 'e.1',
-    Concept(distinguish-01): 'e.5', Concept(possible): 'e.4',
-    (Var(c), ':wiki', "china"): 'e.7'}
+    >>> sorted(a.alignments().items(), key=str)  #doctest:+NORMALIZE_WHITESPACE
+    [((Var(c), ':wiki', "china"), 'e.6'),
+     ((Var(d), ':instance-of', Concept(distinguish-01)), 'e.5'),
+     ((Var(g), ':instance-of', Concept(glance-01)), 'e.2'),
+     ((Var(i), ':instance-of', Concept(i)), 'e.3'),
+     ((Var(n), ':op1', "china"), 'e.6'),
+     ((Var(n2), ':op1', "arizona"), 'e.8'),
+     ((Var(p), ':instance-of', Concept(possible)), 'e.4'),
+     ((Var(s), ':wiki', "arizona"), 'e.8')]
+    >>> sorted(a.role_alignments().items(), key=str)  #doctest:+NORMALIZE_WHITESPACE
+    [((Var(c), ':wiki', "china"), 'e.7'),
+     ((Var(d), ':manner', Var(g)), 'e.0'),
+     ((Var(p), ':domain', Var(d)), 'e.1'),
+     ((Var(s), ':wiki', "arizona"), 'e.7')]
     >>> print(a(alignments=False))
     (p / possible
         :domain (d / distinguish-01


### PR DESCRIPTION
When a concept or constant appears multiple times in an AMR, it would still create just one Concept or AMRConstant object, thus losing any alignment that the other occurrences have.
The default behavior is still to merge repeating occurrences, but now it is possible to avoid this by passing merge_repeating_concepts=False to parse().
This is for backward compatibility: a user could be assuming that concepts are identified only by their name, thus keeping them in an external data structure that is maintained across AMRs, for example.